### PR TITLE
Update

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,5 @@
 # The URL the site will be built for
-#base_url = "https://example.com"
-base_url = "https://zola-themes-demos.github.io/course"
+base_url = "https://example.com"
 
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 # The URL the site will be built for
-base_url = "https://example.com"
+#base_url = "https://example.com"
+base_url = "https://zola-themes-demos.github.io/course"
 
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,7 +34,7 @@
   <meta name="twitter:image" content="{{ get_url(path=default_illus) }}" />
   {% endif %}
   <title>{{ full_title }}</title>
-  <link rel="stylesheet" href="/site.css" media="all">
+  <link rel="stylesheet" href="{{ get_url(path='site.css', trailing_slash=false, cachebust=true) | safe }}" media="all" />
   {% if p.extra.jsonld %}
   <script type="application/ld+json">
     {
@@ -92,7 +92,7 @@
     <p>Ce cours est <a href="{{ config.extra.source_url }}">modifiable par tous</a>.</p>
     <p>Il est sous licence GPLv3.0.</p>
   </footer>
-  <script src="/theme.js"></script>
+  <script src="{{ get_url(path='theme.js', trailing_slash=false) | safe }}" integrity="sha384-{{ get_hash(path='theme.js', sha_type=384, base64=true) | safe }}"></script>
 </body>
 
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,10 +7,10 @@
 <ol class="toc">
     {% for part in section.subsections %}
     {% set part = get_section(path=part) %}
-    <li><a href="{{ part.permalink }}">{{ part.title }}</a>
+    <li><a href="{{ part.permalink | safe }}">{{ part.title }}</a>
         <ol>
             {% for chap in part.pages %}
-            <li><a href="{{ chap.permalink }}">{{ chap.title }}</a></li>
+            <li><a href="{{ chap.permalink | safe }}">{{ chap.title }}</a></li>
             {% endfor %}
         </ol>
     </li>

--- a/templates/page.html
+++ b/templates/page.html
@@ -33,11 +33,11 @@
 {% if previous_link or next_link %}
     <nav>
         {% if previous_link %}
-            <a href="{{ previous_link }}">⇦ Page précédente</a>
+            <a href="{{ previous_link | safe }}">⇦ Page précédente</a>
         {% endif %}
         
         {% if next_link %}
-            <a href="{{ next_link }}">Page suivante ⇨</a>
+            <a href="{{ next_link | safe }}">Page suivante ⇨</a>
         {% endif %}
     </nav>
 {% endif %}

--- a/templates/section.html
+++ b/templates/section.html
@@ -21,7 +21,7 @@
 <ol class="toc">
 {% for chap in section.pages %}
     <li>
-        <a href="{{ chap.permalink }}">{{ chap.title }}</a>
+        <a href="{{ chap.permalink | safe }}">{{ chap.title }}</a>
         <p>{{ chap.description }}</p>
     </li>
 {% endfor %}
@@ -30,11 +30,11 @@
 {% if previous_link or next_link %}
     <nav>
         {% if previous_link %}
-            <a href="{{ previous_link }}">⇦ Page précédente</a>
+            <a href="{{ previous_link | safe }}">⇦ Page précédente</a>
         {% endif %}
         
         {% if next_link %}
-            <a href="{{ next_link }}">Page suivante ⇨</a>
+            <a href="{{ next_link | safe }}">Page suivante ⇨</a>
         {% endif %}
     </nav>
 {% endif %}

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ homepage = "https://github.com/elegaanz/zola-theme-course"
 # The minimum version of Zola required
 min_version = "0.17.1"
 # An optional live demo URL
-demo = "https://zola-themes-demos.github.io/course/"
+demo = "https://c.gelez.xyz/"
 
 # Any variable there can be overridden in the end user `config.toml`
 # You don't need to prefix variables by the theme name but as this will

--- a/theme.toml
+++ b/theme.toml
@@ -3,9 +3,9 @@ description = "A zola theme designed for online courses or tutorials"
 license = "GPL-3.0"
 homepage = "https://github.com/elegaanz/zola-theme-course"
 # The minimum version of Zola required
-min_version = "0.15.0"
+min_version = "0.17.1"
 # An optional live demo URL
-demo = "https://c.gelez.xyz"
+demo = "https://zola-themes-demos.github.io/course/"
 
 # Any variable there can be overridden in the end user `config.toml`
 # You don't need to prefix variables by the theme name but as this will


### PR DESCRIPTION
I noticed your demo has been offline for a long time.

I fixed the theme files so that they can be hosted from a root domain or a subfolder, so for example:

`https://elegaanz.github.io/`
**or**
`https://elegaanz.github.io/course/`

previous because of the root path for the css and js file, this would never work from a subfolder, now it works either way.

I also pointed the demo to one I put up for now, you can merge it as is, or upload your own demo.

Hope this helps.